### PR TITLE
Added skip param to screenMatchesGolden()

### DIFF
--- a/packages/golden_toolkit/lib/src/golden_builder.dart
+++ b/packages/golden_toolkit/lib/src/golden_builder.dart
@@ -187,6 +187,8 @@ Future<void> testGoldens(
 /// [finder] optional finder, defaults to [widgetBuilderKey]
 ///
 /// [customPump] optional pump function, see [CustomPump] documentation
+///
+/// [skip] by setting to true will skip the golden file assertion. This may be necessary if your development platform is not the same as your CI platform
 Future<void> screenMatchesGolden(
   WidgetTester tester,
   String goldenFileName, {

--- a/packages/golden_toolkit/lib/src/golden_builder.dart
+++ b/packages/golden_toolkit/lib/src/golden_builder.dart
@@ -192,6 +192,7 @@ Future<void> screenMatchesGolden(
   String goldenFileName, {
   Finder finder,
   CustomPump customPump = _onlyPumpAndSettle,
+  bool skip = false,
 }) async {
   if (!_inGoldenTest) {
     fail(
@@ -208,6 +209,7 @@ Future<void> screenMatchesGolden(
   return expectLater(
     actualFinder,
     matchesGoldenFile(fileName),
+    skip: skip,
   );
 }
 


### PR DESCRIPTION
# Your checklist for this pull request
- [x] Check the tests are green.

## What did you implement
Added an additional 'skip' parameter to 'screenMatchesGolden' function in order to be able to skip a 'matchesGoldenFile' assertion

## How can we verify the feature || Showcase
n/a