### PR TITLE
tweak implementation to allow manual invocation via VSCode

### DIFF
--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -111,21 +111,23 @@ bool _inGoldenTest = false;
 ///
 /// [test] test body
 ///
-@isTest
+@isTestGroup
 Future<void> testGoldens(
   String description,
   Future<void> Function(WidgetTester) test, {
   bool skip = false,
 }) async {
-  testWidgets('Golden: $description', (tester) async {
-    _inGoldenTest = true;
-    tester.binding.addTime(const Duration(seconds: 10));
-    try {
-      await test(tester);
-    } finally {
-      _inGoldenTest = false;
-    }
-  }, skip: skip);
+  group(description, () {
+    testWidgets('Golden', (tester) async {
+      _inGoldenTest = true;
+      tester.binding.addTime(const Duration(seconds: 10));
+      try {
+        await test(tester);
+      } finally {
+        _inGoldenTest = false;
+      }
+    }, skip: skip);
+  });
 }
 
 /// This [screenMatchesGolden] is wrapper on top of [matchesGoldenFile]


### PR DESCRIPTION
I realized my change I made yesterday worked fine from the command line, but it broke manual invocation of testGoldens from VSCode. 

There does result in a slight change in the overall structure, but I don't think it is necessarily a bad thing. It creates some additional nesting because the test name is actually a group containing a single test "Golden"

<img width="339" alt="image" src="https://user-images.githubusercontent.com/5420324/73599119-ec933200-44f4-11ea-856f-58869112acf1.png">

Manual invocation still doesn't work in Android Studio as it does not respect the **isTest** and **isTestGroup** meta tags. But the tests can still be executed for a parent group or the full file. (I believe these behaviors have always been true with the testGoldens() method)

<img width="421" alt="image" src="https://user-images.githubusercontent.com/5420324/73599190-ad191580-44f5-11ea-9335-df92d358d321.png">

<img width="266" alt="image" src="https://user-images.githubusercontent.com/5420324/73599197-bdc98b80-44f5-11ea-9a9a-650196eb71a2.png">
