### PR TITLE
don't require widgets to be pumped with pumpWidgetBuilder

### DIFF
--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -17,9 +17,6 @@ const Size _defaultSize = Size(800, 600);
 
 typedef WidgetWrapper = Widget Function(Widget);
 
-/// [widgetBuilderKey] is a unique widget key that wraps widget under test and used by GoldenBuilder///
-const widgetBuilderKey = ValueKey('pumpedWidgetKey');
-
 ///CustomPump is a function that lets you do custom pumping before golden evaluation.
 ///Sometimes, you want to do a golden test for different stages of animations, so its crucial to have a precise control over pumps and durations
 typedef CustomPump = Future<void> Function(WidgetTester);
@@ -43,7 +40,7 @@ extension TestingToolsExtension on WidgetTester {
 
     await _pumpAppWidget(
       this,
-      KeyedSubtree(key: widgetBuilderKey, child: _wrapper(widget)),
+      _wrapper(widget),
       surfaceSize: surfaceSize,
       textScaleSize: textScaleSize,
     );
@@ -134,7 +131,7 @@ Future<void> testGoldens(
 ///
 /// [goldenFileName] is a file name output, must NOT include extension like .png
 ///
-/// [finder] optional finder, defaults to [widgetBuilderKey]
+/// [finder] optional finder
 ///
 /// [customPump] optional pump function, see [CustomPump] documentation
 ///
@@ -152,7 +149,9 @@ Future<void> screenMatchesGolden(
     fail(
         'Golden tests MUST be run within a testGoldens method, not just a testWidgets method. This is so we can be confident that running "flutter test --name=GOLDEN" will run all golden tests.');
   }
-  final actualFinder = finder ?? find.byKey(widgetBuilderKey);
+  /* if no finder is specified, use the first widget. Note, there is no guarantee this evaluates top-down, but in theory if all widgets are in the same 
+  RepaintBoundary, it should not matter */
+  final actualFinder = finder ?? find.byWidgetPredicate((w) => true).first;
   final fileName = 'goldens/$goldenFileName.png';
 
   await matchesGoldenFile(fileName).matchAsync(actualFinder);

--- a/packages/golden_toolkit/test/golden_builder_test.dart
+++ b/packages/golden_toolkit/test/golden_builder_test.dart
@@ -21,18 +21,31 @@ Future<void> main() async {
   await loadAppFonts(from: 'fonts');
 
   group('Basic golden test for empty container', () {
-    testGoldens('Square container', (tester) async {
+    final squareContainer = Container(
+      width: 100,
+      height: 100,
+      color: const Color.fromARGB(255, 36, 51, 66),
+    );
+
+    testGoldens('Pump widget traditionally', (tester) async {
+      tester.binding.window.devicePixelRatioTestValue = 1.0;
+      await tester.binding.setSurfaceSize(const Size(200, 200));
+
+      await tester.pumpWidget(squareContainer);
+
+      await screenMatchesGolden(
+        tester,
+        'square_container',
+        // https://github.com/eBay/flutter_glove_box/issues/5
+        skip: !Platform.isMacOS,
+      );
+    });
+
+    testGoldens('Pump widgetBuilder no wrap', (tester) async {
       /// Note: pumpWidgetBuilder will use [materialAppWrapper] by default.
       /// If you want no wrapper at all, pass **noWrap()**
-
-      final widget = Container(
-        width: 100,
-        height: 100,
-        color: const Color.fromARGB(255, 36, 51, 66),
-      );
-
       await tester.pumpWidgetBuilder(
-        widget,
+        squareContainer,
         surfaceSize: const Size(200, 200),
         wrapper: noWrap(),
       );


### PR DESCRIPTION
There was an unintentional assumption baked into the code that widgets would be pumped with pumpWidgetBuilder before screenMatchesGolden would be called.

I eliminated the coupling.