### PR TITLE
provide workaround for testing packages that include fonts directly

### DIFF
--- a/packages/golden_toolkit/CHANGELOG.md
+++ b/packages/golden_toolkit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.2.1-dev
+
+Resolved an issue when using `loadAppFonts()` to unit test a non-application package which includes one or more custom fonts.
+
 ## 0.2.0-dev
 
 Improved the mechanism for loading font assets. Consumers no longer need to supply a directory to read the .ttf files from.

--- a/packages/golden_toolkit/lib/golden_toolkit.dart
+++ b/packages/golden_toolkit/lib/golden_toolkit.dart
@@ -8,7 +8,7 @@
 library golden_toolkit;
 
 export 'src/device.dart';
-export 'src/font_loader.dart';
+export 'src/font_loader.dart' show loadAppFonts;
 export 'src/golden_builder.dart';
 export 'src/multi_screen_golden.dart';
 export 'src/testing_tools.dart';

--- a/packages/golden_toolkit/lib/src/font_loader.dart
+++ b/packages/golden_toolkit/lib/src/font_loader.dart
@@ -7,6 +7,7 @@
 /// ***************************************************
 
 import 'dart:convert';
+import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 
@@ -18,13 +19,13 @@ import 'package:flutter_test/flutter_test.dart';
 ///packages you depend on.
 Future<void> loadAppFonts() async {
   TestWidgetsFlutterBinding.ensureInitialized();
-  final fontManifest = await rootBundle.loadStructuredData<List<dynamic>>(
+  final fontManifest = await rootBundle.loadStructuredData<Iterable<dynamic>>(
     'FontManifest.json',
     (string) async => json.decode(string),
   );
 
   for (final Map<String, dynamic> font in fontManifest) {
-    final fontLoader = FontLoader(_processedFontFamily(font['family']));
+    final fontLoader = FontLoader(derivedFontFamily(font));
     for (final Map<String, dynamic> fontType in font['fonts']) {
       fontLoader.addFont(rootBundle.load(fontType['asset']));
     }
@@ -32,21 +33,32 @@ Future<void> loadAppFonts() async {
   }
 }
 
-String _processedFontFamily(String fontFamily) {
-  /// There is no way to easily load the Roboto or Cupertino fonts.
-  /// To make them available in tests, a package needs to include their own copies of them.
-  ///
-  /// GoldenToolkit supplies Roboto because it is free to use.
-  ///
-  /// However, when a downstream package includes a font, the font family will be prefixed with
-  /// /packages/<package name>/<fontFamily> in order to disambiguate when multiple packages include
-  /// fonts with the same name.
-  ///
-  /// Ultimately, the font loader will load whatever we tell it, so if we see a font that looks like
-  /// a Material or Cupertino font family, let's treat it as the main font family
-  if (fontFamily.startsWith('packages/') &&
-      _overridableFonts.any(fontFamily.contains)) {
-    return fontFamily.split('/').last;
+/// There is no way to easily load the Roboto or Cupertino fonts.
+/// To make them available in tests, a package needs to include their own copies of them.
+///
+/// GoldenToolkit supplies Roboto because it is free to use.
+///
+/// However, when a downstream package includes a font, the font family will be prefixed with
+/// /packages/<package name>/<fontFamily> in order to disambiguate when multiple packages include
+/// fonts with the same name.
+///
+/// Ultimately, the font loader will load whatever we tell it, so if we see a font that looks like
+/// a Material or Cupertino font family, let's treat it as the main font family
+@visibleForTesting
+String derivedFontFamily(Map<String, dynamic> fontDefinition) {
+  final String fontFamily = fontDefinition['family'];
+  if (fontFamily.startsWith('packages/')) {
+    if (_overridableFonts.any(fontFamily.contains)) {
+      return fontFamily.split('/').last;
+    }
+  } else {
+    for (final Map<String, dynamic> fontType in fontDefinition['fonts']) {
+      final String asset = fontType['asset'];
+      if (asset?.startsWith('packages') ?? false) {
+        final packageName = asset.split('/')[1];
+        return 'packages/$packageName/$fontFamily';
+      }
+    }
   }
   return fontFamily;
 }

--- a/packages/golden_toolkit/lib/src/font_loader.dart
+++ b/packages/golden_toolkit/lib/src/font_loader.dart
@@ -47,6 +47,11 @@ Future<void> loadAppFonts() async {
 @visibleForTesting
 String derivedFontFamily(Map<String, dynamic> fontDefinition) {
   final String fontFamily = fontDefinition['family'];
+
+  if (_overridableFonts.contains(fontFamily)) {
+    return fontFamily;
+  }
+
   if (fontFamily.startsWith('packages/')) {
     if (_overridableFonts.any(fontFamily.contains)) {
       return fontFamily.split('/').last;

--- a/packages/golden_toolkit/pubspec.yaml
+++ b/packages/golden_toolkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: golden_toolkit
 description: Common patterns for screenshot-based widget testing using Goldens.
-version: 0.2.0-dev
+version: 0.2.1-dev
 homepage: https://github.com/eBay/flutter_glove_box/
 repository: https://github.com/eBay/flutter_glove_box/tree/master/packages/golden_toolkit
 issue_tracker: https://github.com/eBay/flutter_glove_box/issues

--- a/packages/golden_toolkit/test/font_loading_test.dart
+++ b/packages/golden_toolkit/test/font_loading_test.dart
@@ -38,14 +38,27 @@ Future<void> main() async {
   group('Font Family Derivation', () {
     test('de-namespace Material/Cupertino font overrides', () {
       expect(
+        derivedFontFamily(_font('Roboto', ['packages/foo/fonts/roboto.ttf'])),
+        equals('Roboto'),
+      );
+      expect(
         derivedFontFamily(
             _font('packages/foo/Roboto', ['packages/foo/fonts/roboto.ttf'])),
         equals('Roboto'),
       );
       expect(
+        derivedFontFamily(
+            _font('.SF UI Display', ['packages/foo/fonts/sf.ttf'])),
+        equals('.SF UI Display'),
+      );
+      expect(
         derivedFontFamily(_font(
             'packages/foo/.SF UI Display', ['packages/foo/fonts/sf.ttf'])),
         equals('.SF UI Display'),
+      );
+      expect(
+        derivedFontFamily(_font('.SF UI Text', ['packages/foo/fonts/sf.ttf'])),
+        equals('.SF UI Text'),
       );
       expect(
         derivedFontFamily(


### PR DESCRIPTION
This addresses an issue with trying to load fonts while testing an individual package (not app) that includes a font.

See this comment below for the scenario:

```
/// Imagine you have Package A that depends on Package B.
    /// Package B includes a font family "bar"
    /// In code, package B will need to refer to the font as /packages/B/bar
    ///
    /// in Package A unittest's FontManifest.json , the font family will read as "/packages/A/bar"
    ///
    /// However, in Package B unittest's FontManifest.json, the font family is recorded as simply "bar"
    ///
    /// This will cause the font to fail to be found in Package B's tests.
    ///
    /// Thankfully, the assets are appropriately namespaced, so we can copy that namespace identifier
    /// and modify the fontFamily name before loading into the FontLoader for simulating in our tests
```