### PR TITLE
add support to swap in additional cupertino fonts for the sake of goldens

### DIFF
--- a/packages/golden_toolkit/CHANGELOG.md
+++ b/packages/golden_toolkit/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.3.2
+
+Additional support for Cupertino fonts in Goldens.
+
 ## 0.3.1+1
 
 Corrected the update command in `README.md`.

--- a/packages/golden_toolkit/lib/src/font_loader.dart
+++ b/packages/golden_toolkit/lib/src/font_loader.dart
@@ -72,4 +72,6 @@ const List<String> _overridableFonts = [
   'Roboto',
   '.SF UI Display',
   '.SF UI Text',
+  '.SF Pro Text',
+  '.SF Pro Display',
 ];

--- a/packages/golden_toolkit/pubspec.yaml
+++ b/packages/golden_toolkit/pubspec.yaml
@@ -1,6 +1,6 @@
 name: golden_toolkit
 description: Common patterns for screenshot-based widget testing using Goldens.
-version: 0.3.1+1
+version: 0.3.2
 homepage: https://github.com/eBay/flutter_glove_box/
 repository: https://github.com/eBay/flutter_glove_box/tree/master/packages/golden_toolkit
 issue_tracker: https://github.com/eBay/flutter_glove_box/issues

--- a/packages/golden_toolkit/test/font_loading_test.dart
+++ b/packages/golden_toolkit/test/font_loading_test.dart
@@ -80,6 +80,16 @@ Future<void> main() async {
             _font('packages/foo/.SF UI Text', ['packages/foo/fonts/sf.ttf'])),
         equals('.SF UI Text'),
       );
+      expect(
+        derivedFontFamily(
+            _font('packages/foo/.SF Pro Text', ['packages/foo/fonts/sf.ttf'])),
+        equals('.SF Pro Text'),
+      );
+      expect(
+        derivedFontFamily(_font(
+            'packages/foo/.SF Pro Display', ['packages/foo/fonts/sf.ttf'])),
+        equals('.SF Pro Display'),
+      );
     });
 
     test('leave packaged font families unaltered', () {


### PR DESCRIPTION
We previously allowed for users to supply their own copies of **.SF UI Text** and **.SF UI Display** which are used in some Cupertino widgets. However, we did not have support for **.SF Pro Text** and **.SF Pro Display** which are also used. This expands on this support