### PR TITLE
add more robust and less error prone way to handle configuration via Zones

### DIFF
--- a/packages/golden_toolkit/example/test/flutter_test_config.dart
+++ b/packages/golden_toolkit/example/test/flutter_test_config.dart
@@ -13,12 +13,16 @@ import 'dart:io';
 import 'package:golden_toolkit/golden_toolkit.dart';
 
 Future<void> main(FutureOr<void> Function() testMain) async {
-  GoldenToolkit.configure(GoldenToolkitConfiguration(
-    // Currently, goldens are not generated/validated in CI for this repo. We have settled on the goldens for this package
-    // being captured/validated by developers running on MacOSX. We may revisit this in the future if there is a reason to invest
-    // in more sophistication
-    skipGoldenAssertion: () => !Platform.isMacOS,
-  ));
-  await loadAppFonts();
-  return testMain();
+  return GoldenToolkit.runWithConfiguration(
+    () async {
+      await loadAppFonts();
+      await testMain();
+    },
+    config: GoldenToolkitConfiguration(
+      // Currently, goldens are not generated/validated in CI for this repo. We have settled on the goldens for this package
+      // being captured/validated by developers running on MacOSX. We may revisit this in the future if there is a reason to invest
+      // in more sophistication
+      skipGoldenAssertion: () => !Platform.isMacOS,
+    ),
+  );
 }

--- a/packages/golden_toolkit/lib/src/configuration.dart
+++ b/packages/golden_toolkit/lib/src/configuration.dart
@@ -1,3 +1,7 @@
+import 'dart:async';
+
+import 'package:flutter/foundation.dart';
+
 /// ***************************************************
 /// Copyright 2019-2020 eBay Inc.
 ///
@@ -8,7 +12,6 @@
 
 import 'package:meta/meta.dart';
 import 'package:flutter_test/flutter_test.dart';
-
 import 'device.dart';
 
 /// Manages global state & behavior for the Golden Toolkit
@@ -19,10 +22,32 @@ class GoldenToolkit {
 
   static GoldenToolkitConfiguration _configuration = const GoldenToolkitConfiguration();
 
-  /// the current global configuration for the GoldenToolkit
-  static GoldenToolkitConfiguration get configuration => _configuration;
+  /// Applies a GoldenToolkitConfiguration to a block of code to effectively provide a scoped
+  /// singleton. The configuration will apply to just the injected body function.
+  ///
+  /// In most cases, this can be applied in your flutter_test_config.dart to wrap every test in its own zone
+  static T runWithConfiguration<T>(
+    T Function() body, {
+    @required GoldenToolkitConfiguration config,
+  }) {
+    return runZoned<T>(
+      body,
+      zoneValues: <dynamic, dynamic>{#goldentoolkit.config: config},
+    );
+  }
+
+  /// reads the current configuration for based on the active zone, or else falls back to the global static state.
+  static GoldenToolkitConfiguration get configuration {
+    final dynamic zoneValue = Zone.current[#goldentoolkit.config];
+    if (zoneValue == null) {
+      return _configuration;
+    }
+    return zoneValue;
+  }
 
   /// Invoke this to replace the current Golden Toolkit configuration
+  @Deprecated(
+      'This Global state is being deprecated in favor of using a zoned approach. See GoldenToolkit.runWithConfiguration()')
   static void configure(GoldenToolkitConfiguration configuration) {
     _configuration = configuration;
   }

--- a/packages/golden_toolkit/lib/src/configuration.dart
+++ b/packages/golden_toolkit/lib/src/configuration.dart
@@ -38,11 +38,7 @@ class GoldenToolkit {
 
   /// reads the current configuration for based on the active zone, or else falls back to the global static state.
   static GoldenToolkitConfiguration get configuration {
-    final dynamic zoneValue = Zone.current[#goldentoolkit.config];
-    if (zoneValue == null) {
-      return _configuration;
-    }
-    return zoneValue;
+    return Zone.current[#goldentoolkit.config] ?? _configuration;
   }
 
   /// Invoke this to replace the current Golden Toolkit configuration

--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -119,15 +119,18 @@ void testGoldens(
   Future<void> Function(WidgetTester) test, {
   bool skip = false,
 }) {
+  final dynamic config = Zone.current[#goldenToolkit.config];
   group(description, () {
     testWidgets('Golden', (tester) async {
-      _inGoldenTest = true;
-      tester.binding.addTime(const Duration(seconds: 10));
-      try {
-        await test(tester);
-      } finally {
-        _inGoldenTest = false;
-      }
+      return GoldenToolkit.runWithConfiguration(() async {
+        _inGoldenTest = true;
+        tester.binding.addTime(const Duration(seconds: 10));
+        try {
+          await test(tester);
+        } finally {
+          _inGoldenTest = false;
+        }
+      }, config: config);
     }, skip: skip);
   });
 }

--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -119,7 +119,7 @@ void testGoldens(
   Future<void> Function(WidgetTester) test, {
   bool skip = false,
 }) {
-  final dynamic config = Zone.current[#goldenToolkit.config];
+  final dynamic config = Zone.current[#goldentoolkit.config];
   group(description, () {
     testWidgets('Golden', (tester) async {
       return GoldenToolkit.runWithConfiguration(() async {

--- a/packages/golden_toolkit/test/configuration/flutter_test_config.dart
+++ b/packages/golden_toolkit/test/configuration/flutter_test_config.dart
@@ -1,0 +1,18 @@
+/// ***************************************************
+/// Copyright 2019-2020 eBay Inc.
+///
+/// Use of this source code is governed by a BSD-style
+/// license that can be found in the LICENSE file or at
+/// https://opensource.org/licenses/BSD-3-Clause
+/// ***************************************************
+///
+
+import 'dart:async';
+import 'package:golden_toolkit/golden_toolkit.dart';
+
+Future<void> main(FutureOr<void> Function() testMain) async {
+  // this intentionally shadows the more global setting so that we can validate how things work
+  // without using GoldenToolkit.runWithConfiguration()
+  await loadAppFonts();
+  await testMain();
+}

--- a/packages/golden_toolkit/test/configuration/static_configuration_test.dart
+++ b/packages/golden_toolkit/test/configuration/static_configuration_test.dart
@@ -1,0 +1,11 @@
+import 'package:flutter/material.dart';
+import 'package:golden_toolkit/golden_toolkit.dart';
+
+void main() {
+  testGoldens('legacy static global configuration should still work', (tester) async {
+    //ignore:deprecated_member_use_from_same_package
+    GoldenToolkit.configure(GoldenToolkitConfiguration(skipGoldenAssertion: () => true));
+    await tester.pumpWidget(Container());
+    await screenMatchesGolden(tester, 'this_is_expected_to_skip');
+  });
+}

--- a/packages/golden_toolkit/test/configuration_test.dart
+++ b/packages/golden_toolkit/test/configuration_test.dart
@@ -14,11 +14,6 @@ import 'package:golden_toolkit/golden_toolkit.dart';
 void main() {
   group('GoldenToolkitConfiguration Tests', () {
     testGoldens('screenMatchesGolden method should defer skip to global configuration', (tester) async {
-      await tester.pumpWidget(Container());
-      await screenMatchesGolden(tester, 'this_is_expected_to_skip');
-    });
-
-    testGoldens('screenMatchesGolden method should defer skip to global configuration', (tester) async {
       return GoldenToolkit.runWithConfiguration(
         () async {
           await tester.pumpWidget(Container());

--- a/packages/golden_toolkit/test/configuration_test.dart
+++ b/packages/golden_toolkit/test/configuration_test.dart
@@ -14,46 +14,71 @@ import 'package:golden_toolkit/golden_toolkit.dart';
 void main() {
   group('GoldenToolkitConfiguration Tests', () {
     testGoldens('screenMatchesGolden method should defer skip to global configuration', (tester) async {
-      GoldenToolkit.configure(GoldenToolkitConfiguration(skipGoldenAssertion: () => true));
       await tester.pumpWidget(Container());
       await screenMatchesGolden(tester, 'this_is_expected_to_skip');
     });
 
+    testGoldens('screenMatchesGolden method should defer skip to global configuration', (tester) async {
+      return GoldenToolkit.runWithConfiguration(
+        () async {
+          await tester.pumpWidget(Container());
+          await screenMatchesGolden(tester, 'this_is_expected_to_skip');
+        },
+        config: GoldenToolkitConfiguration(skipGoldenAssertion: () => true),
+      );
+    });
+
     testGoldens('screenMatchesGolden method level skip should trump global configuration', (tester) async {
-      GoldenToolkit.configure(GoldenToolkitConfiguration(skipGoldenAssertion: () => false));
-      await tester.pumpWidgetBuilder(Container());
-      //ignore: deprecated_member_use_from_same_package
-      await screenMatchesGolden(tester, 'this_is_expected_to_skip', skip: true);
+      return GoldenToolkit.runWithConfiguration(
+        () async {
+          await tester.pumpWidgetBuilder(Container());
+          //ignore: deprecated_member_use_from_same_package
+          await screenMatchesGolden(tester, 'this_is_expected_to_skip', skip: true);
+        },
+        config: GoldenToolkitConfiguration(skipGoldenAssertion: () => false),
+      );
     });
 
     testGoldens('MultiScreenGolden method should defer skip to global configuration', (tester) async {
-      GoldenToolkit.configure(GoldenToolkitConfiguration(skipGoldenAssertion: () => true));
-      await tester.pumpWidgetBuilder(Container());
-      await multiScreenGolden(tester, 'this_is_expected_to_skip');
+      return GoldenToolkit.runWithConfiguration(
+        () async {
+          await tester.pumpWidgetBuilder(Container());
+          await multiScreenGolden(tester, 'this_is_expected_to_skip');
+        },
+        config: GoldenToolkitConfiguration(skipGoldenAssertion: () => true),
+      );
     });
 
     testGoldens('MultiScreenGolden method level skip should trump global configuration', (tester) async {
-      GoldenToolkit.configure(GoldenToolkitConfiguration(skipGoldenAssertion: () => false));
-      await tester.pumpWidgetBuilder(Container());
-      //ignore: deprecated_member_use_from_same_package
-      await multiScreenGolden(tester, 'this_is_expected_to_skip', skip: true);
+      return GoldenToolkit.runWithConfiguration(
+        () async {
+          await tester.pumpWidgetBuilder(Container());
+          //ignore: deprecated_member_use_from_same_package
+          await multiScreenGolden(tester, 'this_is_expected_to_skip', skip: true);
+        },
+        config: GoldenToolkitConfiguration(skipGoldenAssertion: () => false),
+      );
     });
 
     testGoldens('screenMatchesGolden method should defer fileNameFactory to global configuration', (tester) async {
-      GoldenToolkit.configure(
-        GoldenToolkitConfiguration(fileNameFactory: (name) => 'goldens/custom/custom_$name.png'),
+      return GoldenToolkit.runWithConfiguration(
+        () async {
+          await tester.pumpWidgetBuilder(Container());
+          await screenMatchesGolden(tester, 'global_file_name_factory');
+        },
+        config: GoldenToolkit.configuration.copyWith(fileNameFactory: (name) => 'goldens/custom/custom_$name.png'),
       );
-      await tester.pumpWidgetBuilder(Container());
-      await screenMatchesGolden(tester, 'global_file_name_factory');
     });
 
     testGoldens('multiScreenGolden method should defer fileNameFactory to global configuration', (tester) async {
-      GoldenToolkit.configure(
-        GoldenToolkitConfiguration(
-            deviceFileNameFactory: (name, device) => 'goldens/custom/custom_${name}_${device.name}.png'),
+      return GoldenToolkit.runWithConfiguration(
+        () async {
+          await tester.pumpWidgetBuilder(Container());
+          await multiScreenGolden(tester, 'global_device_file_name_factory');
+        },
+        config: GoldenToolkit.configuration
+            .copyWith(deviceFileNameFactory: (name, device) => 'goldens/custom/custom_${name}_${device.name}.png'),
       );
-      await tester.pumpWidgetBuilder(Container());
-      await multiScreenGolden(tester, 'global_device_file_name_factory');
     });
 
     test('Default Configuration', () {

--- a/packages/golden_toolkit/test/flutter_test_config.dart
+++ b/packages/golden_toolkit/test/flutter_test_config.dart
@@ -13,12 +13,16 @@ import 'dart:io';
 import 'package:golden_toolkit/golden_toolkit.dart';
 
 Future<void> main(FutureOr<void> Function() testMain) async {
-  GoldenToolkit.configure(GoldenToolkitConfiguration(
-    // Currently, goldens are not generated/validated in CI for this repo. We have settled on the goldens for this package
-    // being captured/validated by developers running on MacOSX. We may revisit this in the future if there is a reason to invest
-    // in more sophistication
-    skipGoldenAssertion: () => !Platform.isMacOS,
-  ));
-  await loadAppFonts();
-  return testMain();
+  return GoldenToolkit.runWithConfiguration(
+    () async {
+      await loadAppFonts();
+      await testMain();
+    },
+    config: GoldenToolkitConfiguration(
+      // Currently, goldens are not generated/validated in CI for this repo. We have settled on the goldens for this package
+      // being captured/validated by developers running on MacOSX. We may revisit this in the future if there is a reason to invest
+      // in more sophistication
+      skipGoldenAssertion: () => !Platform.isMacOS,
+    ),
+  );
 }

--- a/packages/golden_toolkit/test/platform_agnostic_test.dart
+++ b/packages/golden_toolkit/test/platform_agnostic_test.dart
@@ -7,11 +7,14 @@ void main() {
   group('Platform agnostic golden', () {
     // this test is intended to run on all platforms, with the assumption that it will
     // generate the same pixels regardless of where it is run
-    GoldenToolkit.configure(const GoldenToolkitConfiguration());
-
     testGoldens('empty container should look right', (tester) async {
-      await tester.pumpWidget(Container());
-      await screenMatchesGolden(tester, 'empty_container');
+      await GoldenToolkit.runWithConfiguration(
+        () async {
+          await tester.pumpWidget(Container());
+          await screenMatchesGolden(tester, 'empty_container');
+        },
+        config: GoldenToolkit.configuration.copyWith(skipGoldenAssertion: () => false),
+      );
     });
   });
 }


### PR DESCRIPTION
deprecating the global static state in favor of using a Zoned approach.

In the vast majority of cases, configuration will likely only occur in flutter_test_config.dart but if there is a need to specify it more granularly, then this provides a safe way to do it that won't cause the state to bleed across tests.