### PR TITLE
docs: flutter_test_config fix

### DIFF
--- a/packages/golden_toolkit/README.md
+++ b/packages/golden_toolkit/README.md
@@ -265,7 +265,7 @@ import 'dart:async';
 
 import 'package:golden_toolkit/golden_toolkit.dart';
 
-Future<void> main(FutureOr<void> testMain()) async {
+Future<void> testExecutable(FutureOr<void> testMain()) async {
   await loadAppFonts();
   return testMain();
 }


### PR DESCRIPTION
When the main method in flutter_test_config.dart is named as "main", an exception is thrown looking for testExecutable. Renaming my main method to testExecutable runs tests fine.