### PR TITLE
Update package fonts logic

### DIFF
--- a/packages/golden_toolkit/lib/src/font_loader.dart
+++ b/packages/golden_toolkit/lib/src/font_loader.dart
@@ -53,8 +53,9 @@ String derivedFontFamily(Map<String, dynamic> fontDefinition) {
   }
 
   if (fontFamily.startsWith('packages/')) {
-    if (_overridableFonts.any(fontFamily.contains)) {
-      return fontFamily.split('/').last;
+    final fontFamilyName = fontFamily.split('/').last;
+    if (_overridableFonts.any((font) => font == fontFamilyName)) {
+      return fontFamilyName;
     }
   } else {
     for (final Map<String, dynamic> fontType in fontDefinition['fonts']) {

--- a/packages/golden_toolkit/test/font_loading_test.dart
+++ b/packages/golden_toolkit/test/font_loading_test.dart
@@ -95,6 +95,11 @@ Future<void> main() async {
             _font('packages/foo/bar', ['packages/foo/fonts/bar.ttf'])),
         equals('packages/foo/bar'),
       );
+      expect(
+        derivedFontFamily(_font(
+            'packages/foo/RobotoMono', ['packages/foo/fonts/RobotoMono.ttf'])),
+        equals('packages/foo/RobotoMono'),
+      );
     });
 
     test('leave unpackaged fonts unaltered', () {


### PR DESCRIPTION
This fixes an issue outline in issue https://github.com/eBay/flutter_glove_box/issues/85 where packaged fonts with certain fontFamily names were not actually being treated as packaged fonts.

I added a test but if you want further verification, you can add this branch to dependencies inside `app/pubspec.yaml` in [this demo repo I made](https://github.com/NickalasB/golden_font_issue)
```
-  golden_toolkit: ^0.8.0
+  golden_toolkit:
+    git:
+      url: https://github.com/NickalasB/flutter_glove_box.git
+      path: packages/golden_toolkit
+      ref: update_package_fonts_logic
```

Once you have done that, delete the `app/build` directory and regenerate Goldens. You should see the properly rendered `RobotoMono` font in the Golden now.

<img width="247" alt="Screen Shot 2020-11-15 at 9 35 20 PM" src="https://user-images.githubusercontent.com/16969303/99222382-4d93aa00-2797-11eb-91a2-91ed4f8dbce3.png">
