### PR TITLE
Use a null default skip value in testGoldens so it can inherit the group's skip flag

### DIFF
--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -145,7 +145,7 @@ bool _inGoldenTest = false;
 void testGoldens(
   String description,
   Future<void> Function(WidgetTester) test, {
-  bool skip = false,
+  bool? skip,
 }) {
   final dynamic config = Zone.current[#goldentoolkit.config];
   group(description, () {


### PR DESCRIPTION
Related to #97, flutter/flutter#76174
