### PR TITLE
Add MediaQuery wrapper to DeviceBuilder 

### DIFF
--- a/packages/given_when_then/analysis_options.yaml
+++ b/packages/given_when_then/analysis_options.yaml
@@ -54,7 +54,6 @@ linter:
     - always_put_control_body_on_new_line
     - always_require_non_null_named_parameters
     - annotate_overrides
-    - avoid_as
     - avoid_field_initializers_in_const_classes
     - avoid_renaming_method_parameters
     - avoid_returning_null_for_void

--- a/packages/golden_toolkit/lib/src/device_builder.dart
+++ b/packages/golden_toolkit/lib/src/device_builder.dart
@@ -176,10 +176,13 @@ class _DeviceScenarioWidget extends StatelessWidget {
       device.size.width + (_horizontalScenarioPadding * 2) + (_borderWidth * 2),
       device.size.height + 24 + (_borderWidth * 2));
 
-  Widget get _sizedWidget => Container(
-        width: device.size.width,
-        height: device.size.height,
-        child: widget,
+  Widget get _sizedWidget => MediaQuery(
+        data: MediaQueryData(size: device.size),
+        child: Container(
+          width: device.size.width,
+          height: device.size.height,
+          child: widget,
+        ),
       );
 
   @override

--- a/packages/golden_toolkit/lib/src/device_builder.dart
+++ b/packages/golden_toolkit/lib/src/device_builder.dart
@@ -176,19 +176,27 @@ class _DeviceScenarioWidget extends StatelessWidget {
       device.size.width + (_horizontalScenarioPadding * 2) + (_borderWidth * 2),
       device.size.height + 24 + (_borderWidth * 2));
 
-  Widget get _sizedWidget => MediaQuery(
-        data: MediaQueryData(
-          size: device.size,
-          padding: device.safeArea,
-          platformBrightness: device.brightness,
-          devicePixelRatio: device.devicePixelRatio,
-          textScaleFactor: device.textScale,
-        ),
-        child: Container(
-          width: device.size.width,
-          height: device.size.height,
-          child: widget,
-        ),
+  Widget get _sizedWidget => Builder(
+        builder: (context) {
+          final mediaQuery =
+              MediaQuery.maybeOf(context) ?? const MediaQueryData();
+          final mergedMediaQuery = mediaQuery.copyWith(
+            size: device.size,
+            padding: device.safeArea,
+            platformBrightness: device.brightness,
+            devicePixelRatio: device.devicePixelRatio,
+            textScaleFactor: device.textScale,
+          );
+
+          return MediaQuery(
+            data: mergedMediaQuery,
+            child: Container(
+              width: device.size.width,
+              height: device.size.height,
+              child: widget,
+            ),
+          );
+        },
       );
 
   @override

--- a/packages/golden_toolkit/lib/src/device_builder.dart
+++ b/packages/golden_toolkit/lib/src/device_builder.dart
@@ -177,7 +177,13 @@ class _DeviceScenarioWidget extends StatelessWidget {
       device.size.height + 24 + (_borderWidth * 2));
 
   Widget get _sizedWidget => MediaQuery(
-        data: MediaQueryData(size: device.size),
+        data: MediaQueryData(
+          size: device.size,
+          padding: device.safeArea,
+          platformBrightness: device.brightness,
+          devicePixelRatio: device.devicePixelRatio,
+          textScaleFactor: device.textScale,
+        ),
         child: Container(
           width: device.size.width,
           height: device.size.height,

--- a/packages/golden_toolkit/test/device_builder_test.dart
+++ b/packages/golden_toolkit/test/device_builder_test.dart
@@ -274,5 +274,35 @@ void main() {
 
       await tester.pumpDeviceBuilder(sut);
     });
+
+    testGoldens('wrap with MediaQuery merges with Device size', (tester) async {
+      // given
+      const device = Device(
+        name: 'deviceName',
+        size: Size.square(200),
+      );
+
+      final widget = Builder(builder: (context) {
+        final mediaQuery = MediaQuery.of(context);
+        assert(mediaQuery.size == device.size);
+        assert(mediaQuery.alwaysUse24HourFormat);
+        return Container();
+      });
+
+      final sut = DeviceBuilder(
+        wrap: (child) => MediaQuery(
+          data: const MediaQueryData(alwaysUse24HourFormat: true),
+          child: child,
+        ),
+      );
+      sut.overrideDevicesForAllScenarios(devices: [device]);
+
+      sut.addScenario(
+        name: 'scenario',
+        widget: widget,
+      );
+
+      await tester.pumpDeviceBuilder(sut);
+    });
   });
 }

--- a/packages/golden_toolkit/test/device_builder_test.dart
+++ b/packages/golden_toolkit/test/device_builder_test.dart
@@ -251,31 +251,9 @@ void main() {
       await screenMatchesGolden(tester, 'device_builder_test');
     });
 
-    testGoldens('MediaQuery.of(context).size in Scenario equals Device size',
+    testGoldens(
+        'Merged MediaQuery has correct Device size and correct override',
         (tester) async {
-      // given
-      const device = Device(
-        name: 'deviceName',
-        size: Size.square(200),
-      );
-
-      final widget = Builder(builder: (context) {
-        assert(MediaQuery.of(context).size == device.size);
-        return Container();
-      });
-
-      final sut = DeviceBuilder();
-      sut.overrideDevicesForAllScenarios(devices: [device]);
-
-      sut.addScenario(
-        name: 'scenario',
-        widget: widget,
-      );
-
-      await tester.pumpDeviceBuilder(sut);
-    });
-
-    testGoldens('wrap with MediaQuery merges with Device size', (tester) async {
       // given
       const device = Device(
         name: 'deviceName',

--- a/packages/golden_toolkit/test/device_builder_test.dart
+++ b/packages/golden_toolkit/test/device_builder_test.dart
@@ -250,5 +250,29 @@ void main() {
 
       await screenMatchesGolden(tester, 'device_builder_test');
     });
+
+    testGoldens('MediaQuery.of(context).size in Scenario equals Device size',
+        (tester) async {
+      // given
+      const device = Device(
+        name: 'deviceName',
+        size: Size.square(200),
+      );
+
+      final widget = Builder(builder: (context) {
+        assert(MediaQuery.of(context).size == device.size);
+        return Container();
+      });
+
+      final sut = DeviceBuilder();
+      sut.overrideDevicesForAllScenarios(devices: [device]);
+
+      sut.addScenario(
+        name: 'scenario',
+        widget: widget,
+      );
+
+      await tester.pumpDeviceBuilder(sut);
+    });
   });
 }

--- a/packages/page_object/analysis_options.yaml
+++ b/packages/page_object/analysis_options.yaml
@@ -54,7 +54,6 @@ linter:
     - always_put_control_body_on_new_line
     - always_require_non_null_named_parameters
     - annotate_overrides
-    - avoid_as
     - avoid_field_initializers_in_const_classes
     - avoid_renaming_method_parameters
     - avoid_returning_null_for_void


### PR DESCRIPTION
relates to #108 

Adding a mediaquery widget allows for code like

```
Container(
    width: MediaQuery.of(context).size.width / 3,
    height: 800,
    child: ...,
);
```

to work properly with the DeviceBuilder. 