### PR TITLE
Allow passing Object as description for testGoldens

### DIFF
--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -143,7 +143,7 @@ bool _inGoldenTest = false;
 ///
 @isTestGroup
 void testGoldens(
-  String description,
+  Object description,
   Future<void> Function(WidgetTester) test, {
   bool skip = false,
 }) {


### PR DESCRIPTION
This is in line with the `group` method signature and and especially allows passing `Type` instances as description. 