### PR TITLE
updating lock files and adding dart_test yaml

### DIFF
--- a/packages/golden_toolkit/README.md
+++ b/packages/golden_toolkit/README.md
@@ -206,6 +206,18 @@ When golden tests fail, artifacts are generated in a `failures` folder adjacent 
 **/failures/*.png
 ```
 
+#### Add a "golden" tag to your project
+
+Add a `dart_test.yaml` file to the root of your project with the following content:
+
+```yaml
+tags:
+  golden:
+```
+
+This will indicate that goldens are an expected test tag. All tests that use `testGoldens()` will automatically be given this tag.
+This allows you to easily target golden tests from the commandline.
+
 #### Configure VS Code
 
 If you use VSCode, we highly recommend adding this configuration to your `.vscode/launch.json` file in the root of your workspace.
@@ -302,7 +314,7 @@ flutter test --update-goldens
 By default, this will execute all tests in the package. In a package with a large number of non-golden widget tests, we found this to be sub-optimal. We would much rather run ONLY the golden tests when regenerating. Initially, we arrived at a convention of ensuring that the test descriptions included the word 'Golden'
 
 ```sh
-flutter test --update-goldens --name=Golden
+flutter test --update-goldens --tags=golden
 ```
 
 However, there wasn't a way to enforce that developers named their tests appropriately, and this was error-prone.

--- a/packages/golden_toolkit/dart_test.yaml
+++ b/packages/golden_toolkit/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  golden:

--- a/packages/golden_toolkit/example/pubspec.lock
+++ b/packages/golden_toolkit/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -157,4 +157,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-29.10.beta <3.0.0"
+  dart: ">=2.12.0 <3.0.0"

--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -149,7 +149,7 @@ const Object _defaultTagObject = Object();
 void testGoldens(
   String description,
   Future<void> Function(WidgetTester) test, {
-  bool skip = false,
+  bool? skip,
   Object? tags = _defaultTagObject,
 }) {
   final dynamic config = Zone.current[#goldentoolkit.config];

--- a/packages/golden_toolkit/pubspec.lock
+++ b/packages/golden_toolkit/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.5.0"
+    version: "2.6.1"
   boolean_selector:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0"
+    version: "1.8.1"
   stack_trace:
     dependency: transitive
     description:
@@ -141,7 +141,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.19"
+    version: "0.3.0"
   typed_data:
     dependency: transitive
     description:
@@ -157,4 +157,4 @@ packages:
     source: hosted
     version: "2.1.0"
 sdks:
-  dart: ">=2.12.0-0.0 <3.0.0"
+  dart: ">=2.12.0 <3.0.0"


### PR DESCRIPTION
adding dart_test.yaml to define that "goldens" is an expected tag. This eliminates warnings during flutter test