### PR TITLE
Change @isTestGroup to @isTest on testGoldens

### DIFF
--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -145,7 +145,7 @@ const Object _defaultTagObject = Object();
 ///
 /// [test] test body
 ///
-@isTestGroup
+@isTest
 void testGoldens(
   String description,
   Future<void> Function(WidgetTester) test, {


### PR DESCRIPTION
The `testGoldens` function currently has an `@isTestGroup` annotation, but the function just represents a test, not a group. It looks like it used to contain a group, but that was removed in favour of tags in https://github.com/eBay/flutter_glove_box/commit/f1d486c77853fe3b17276455a94fec083bc2b6c8. This annotation appears to have been overlooked.

With this set to group, the VS Code extension fails to merge the results from running the tests (where it gets a _test_ with this name) and the analyzer discovery results (where it gets a _group_ based on the annotation). The error has been fixed in https://github.com/Dart-Code/Dart-Code/issues/3776, however even with that fix, the tree will now show both a test and a group with this name (since groups and tests are never merged together).

Changing the annotation to `@isTest` fixes this, and everything works as expected.

Related PRs/commits:

- https://github.com/eBay/flutter_glove_box/pull/8
- https://github.com/eBay/flutter_glove_box/commit/f1d486c77853fe3b17276455a94fec083bc2b6c8