### PR TITLE
Expose a method to override rendering of the final generated image

### DIFF
--- a/packages/golden_toolkit/lib/src/configuration.dart
+++ b/packages/golden_toolkit/lib/src/configuration.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:ui';
 
 import 'package:flutter/foundation.dart';
 
@@ -20,8 +21,7 @@ import '../golden_toolkit.dart';
 class GoldenToolkit {
   GoldenToolkit._();
 
-  static GoldenToolkitConfiguration _configuration =
-      GoldenToolkitConfiguration();
+  static GoldenToolkitConfiguration _configuration = GoldenToolkitConfiguration();
 
   /// Applies a GoldenToolkitConfiguration to a block of code to effectively provide a scoped
   /// singleton. The configuration will apply to just the injected body function.
@@ -52,6 +52,10 @@ class GoldenToolkit {
 
 /// A func that will be evaluated at runtime to determine if the golden assertion should be skipped
 typedef SkipGoldenAssertion = bool Function();
+
+/// a function that returns a Future<ui.Image> given a Finder & Tester.
+/// A typical example is to draw boxes instead of paragraphs when rendering the UI to get consistent results across platforms
+typedef RenderModification = Future<Image> Function({required Finder finder, required WidgetTester tester});
 
 /// A factory to determine an actual file name/path from a given name.
 ///
@@ -88,6 +92,9 @@ class GoldenToolkitConfiguration {
   ///
   /// [primeAssets] a func that is used to ensure that all images have been decoded before trying to render
   ///
+  /// [renderModification] a func that returns a Future<ui.Image> given a Finder & Tester.
+  /// A typical example is to draw boxes instead of paragraphs when rendering the UI to get consistent results across platforms
+  ///
   /// [enableRealShadows] a flag indicating that we want the goldens to have real shadows (instead of opaque shadows)
   ///
   /// [tags] a string or iterable of strings used to tag golden tests with
@@ -99,10 +106,15 @@ class GoldenToolkitConfiguration {
     this.defaultDevices = const [Device.phone, Device.tabletLandscape],
     this.enableRealShadows = false,
     this.tags = const ['golden'],
+    this.renderModification,
   }) : assert(defaultDevices.isNotEmpty);
 
   /// a function indicating whether a golden assertion should be skipped
   final SkipGoldenAssertion skipGoldenAssertion;
+
+  /// a function that returns a Future<ui.Image> given a Finder & Tester.
+  /// A typical example is to draw boxes instead of paragraphs when rendering the UI to get consistent results across platforms
+  final RenderModification? renderModification;
 
   /// A function to determine the file name/path [screenMatchesGolden] uses to call [matchesGoldenFile].
   final FileNameFactory fileNameFactory;
@@ -138,8 +150,7 @@ class GoldenToolkitConfiguration {
     return GoldenToolkitConfiguration(
       skipGoldenAssertion: skipGoldenAssertion ?? this.skipGoldenAssertion,
       fileNameFactory: fileNameFactory ?? this.fileNameFactory,
-      deviceFileNameFactory:
-          deviceFileNameFactory ?? this.deviceFileNameFactory,
+      deviceFileNameFactory: deviceFileNameFactory ?? this.deviceFileNameFactory,
       primeAssets: primeAssets ?? this.primeAssets,
       defaultDevices: defaultDevices ?? this.defaultDevices,
       enableRealShadows: enableRealShadows ?? this.enableRealShadows,

--- a/packages/golden_toolkit/lib/src/testing_tools.dart
+++ b/packages/golden_toolkit/lib/src/testing_tools.dart
@@ -292,11 +292,20 @@ Future<void> compareWithGolden(
     await tester.pump();
   }
 
-  await expectLater(
-    actualFinder,
-    matchesGoldenFile(fileName),
-    skip: shouldSkipGoldenGeneration,
-  );
+  if (GoldenToolkit.configuration.renderModification != null) {
+    final ciImage = GoldenToolkit.configuration.renderModification!(finder: actualFinder, tester: tester);
+    await expectLater(
+      ciImage,
+      matchesGoldenFile(fileName),
+      skip: shouldSkipGoldenGeneration,
+    );
+  } else {
+    await expectLater(
+      actualFinder,
+      matchesGoldenFile(fileName),
+      skip: shouldSkipGoldenGeneration,
+    );
+  }
 
   if (autoHeight == true) {
     // Here we reset the window size to its original value to be clean


### PR DESCRIPTION
We prefer the golden_toolkit methodology of setting up golden tests above other packages currently available.
However, probably the number one issue at this point is consistent UI tests across platforms. Even with the Ahem font, these squares do not render consistently accross platforms, due to issues with font smoothing, text scaling differences, etc.
Other packages (such as alchemist) have workarounds for this, like replacing all rendered paragraphs with rendered rectangles instead.

To allow us the best of both worlds, I exposed a new function in the configuration for golden_toolkit which allows providing a method which will run right before the golden tests are generated. This allows developers to (for example) hook-in the rectangle rendering for fonts of the alchemist package (https://github.com/Betterment/alchemist/blob/main/lib/src/blocked_text_image.dart) which will generate consistent golden tests across all platforms, or do more advanced stuff.