### PR TITLE
"physicalSizeTestValue" should be "logical size * pixel ratio"

### DIFF
--- a/packages/golden_toolkit/lib/src/widget_tester_extensions.dart
+++ b/packages/golden_toolkit/lib/src/widget_tester_extensions.dart
@@ -44,7 +44,7 @@ extension WidgetFlutterBindingExtensions on TestWidgetsFlutterBinding {
   ///
   Future<void> applyDeviceOverrides(Device device) async {
     await setSurfaceSize(Size(device.size.width, device.size.height));
-    this.window.physicalSizeTestValue = device.size;
+    this.window.physicalSizeTestValue = device.size * device.devicePixelRatio;
     this.window.devicePixelRatioTestValue = device.devicePixelRatio;
     this.window.platformDispatcher.textScaleFactorTestValue = device.textScale;
     this.window.platformDispatcher.platformBrightnessTestValue =

--- a/packages/golden_toolkit/test/multi_screen_golden_test.dart
+++ b/packages/golden_toolkit/test/multi_screen_golden_test.dart
@@ -101,6 +101,37 @@ Future<void> main() async {
         expect(tester.binding.window.padding, equals(initialViewInsets));
       });
 
+      testGoldens('Maintain physical size in pumped widget', (tester) async {
+        bool firstPump = true;
+        const defaultSize = Size(800, 600);
+        const desiredSize = Size(50, 75);
+        await tester.pumpWidgetBuilder(StreamBuilder(builder: (context, _) {
+          if (firstPump) {
+            expect(MediaQuery
+                .of(context)
+                .size, equals(defaultSize));
+            firstPump = false;
+          } else {
+            expect(MediaQuery.of(context).size, equals(desiredSize));
+          }
+          return const Text('Done');
+        }));
+        await multiScreenGolden(
+          tester,
+          'desiredSize',
+          devices: [
+            const Device(
+              name: 'anything',
+              size: desiredSize,
+              brightness: Brightness.light,
+              safeArea: EdgeInsets.all(4),
+              devicePixelRatio: 2.0,
+              textScale: 1.0,
+            )
+          ],
+        );
+      });
+
       testGoldens('Should expand scrollable if autoHeight is true',
           (tester) async {
         await tester.pumpWidgetBuilder(ListView.builder(


### PR DESCRIPTION
My goal is to use the generated golden screenshots as "preview assets" in Google Play and the App Store. For the App Store however, I need to deliver these in a higher resolution. So I created a custom `Device` with `devicePixelRatio: 2`, but the resulting `png` file is still the same size. After some debugging, I figured out that, when building the widget, the actual `MediaQuery.size` is cut in half. Thanks to the `devicePixelRatio`, the resulting image is doubled, so it's still the same as when using a ratio of 1.

I've written a small test to reproduce this behavior. Is there a reason to scale the final image as if a `devicePixelRatio` of 1 was being used?

On an aside, in order to make sure that the `size` and and `devicePixelRatio` values are set as expected, I modified my AVD emulator from:
```ini
hw.lcd.density = 160
hw.lcd.height = 640
hw.lcd.width = 320
```
which resulted in:
 * Size: 320, 640
 * devicePixelRatio: 1.0

to 

```ini
hw.lcd.density = 320
hw.lcd.height = 1280
hw.lcd.width = 640
```
which resulted in:
 * Size: 320, 640
 * devicePixelRatio: 2.0

These values are printouts of the `MediaQuery` in the widget's`build()` method, and this is how I found out about the "reverse scaling" in the first place.

I'm going to dig deeper now in order to find a possible solution, but I already wanted to ask about possible reasons for doing so.