### PR TITLE
Support asset paths that include % and [, etc

### DIFF
--- a/packages/golden_toolkit/lib/src/font_loader.dart
+++ b/packages/golden_toolkit/lib/src/font_loader.dart
@@ -27,7 +27,10 @@ Future<void> loadAppFonts() async {
   for (final Map<String, dynamic> font in fontManifest) {
     final fontLoader = FontLoader(derivedFontFamily(font));
     for (final Map<String, dynamic> fontType in font['fonts']) {
-      fontLoader.addFont(rootBundle.load(fontType['asset']));
+      // Some characters such as % and [ in the asset path included in fontType
+      // are encoded.
+      final decodedAsset = Uri.decodeComponent(fontType['asset']);
+      fontLoader.addFont(rootBundle.load(decodedAsset));
     }
     await fontLoader.load();
   }


### PR DESCRIPTION
Hi team, thank you for the great package!
I found a small problem, and tried to fix it. Could you please check it?

## Error details

In the current release, the following error occurs when characters such as `%` are used in the asset path.

```
package:flutter/src/services/asset_bundle.dart 339:7  PlatformAssetBundle.load
package:golden_toolkit/src/font_loader.dart 30:37     loadAppFonts

Unable to load asset: "packages/custom_font/fonts/Raleway-Regular%25test.ttf".
The asset does not exist or has empty data.
```

I found that some characters such as `%` and `[` in the asset path included in fontType are encoded. For example, `Raleway-Regular!@$%^&*()[].ttf` will be `Raleway-Regular!@$%25%5E&*()%5B%5D.ttf`.

### How to reproduce

Create a package containing custom fonts like below.

```yaml
flutter:
  fonts:
    - family: Raleway
      fonts:
        - asset: fonts/Raleway-Regular%test.ttf
```

And the create a widget using this font.

```dart
class CustomFontLabel extends StatelessWidget {
  const CustomFontLabel({super.key, required this.text});

  final String text;

  @override
  Widget build(BuildContext context) {
    return Text(
      text,
      style: const TextStyle(
        fontFamily: 'Raleway',
        package: 'custom_font',
        fontSize: 46,
      ),
    );
  }
}
```

Write a golden test using this widget on the app side, and it will fail.

```dart
void main() {
  setUp(() async {
    await loadAppFonts();
  });

  testGoldens('test', (tester) async {
    const widget = WidgetUsingCustomFontLabel();
    await tester.pumpWidgetBuilder(
      widget,
      wrapper: materialAppWrapper(),
    );
    await screenMatchesGolden(tester, 'test');
  });
}
```