### PR TITLE
Support loading new Flutter 3.19 Cupertino font families

### DIFF
--- a/packages/golden_toolkit/lib/src/font_loader.dart
+++ b/packages/golden_toolkit/lib/src/font_loader.dart
@@ -79,4 +79,6 @@ const List<String> _overridableFonts = [
   '.SF UI Text',
   '.SF Pro Text',
   '.SF Pro Display',
+  'CupertinoSystemText',
+  'CupertinoSystemDisplay',
 ];


### PR DESCRIPTION
* fixes #188 